### PR TITLE
Be more specific about the location parameter

### DIFF
--- a/R/getCDL.R
+++ b/R/getCDL.R
@@ -6,7 +6,7 @@
 #'  a state name.
 #'@param year A numerical vector. A set of years of CDL data to download.
 #'@param alternativeUrl An optional string containing an alternative url.
-#'@param location An optional string containing a location to store the file.
+#'@param location An optional string containing a folder to store the file.
 #'@param https An optional boolean to turn on and off https, default is on.
 #'@param ssl.verifypeer An optional boolean to turn on and off ssl verfication, default is on.
 #'@return A list of CDL raster objects of interested county for a set of years.


### PR DESCRIPTION
I thought the text might be unclear whether `location` was a file location (ending in `.tif`) or a folder location.