### PR TITLE
specify progress import from httr

### DIFF
--- a/R/getCDL.R
+++ b/R/getCDL.R
@@ -24,8 +24,7 @@
 #' @author Joseph Stachelek, \email{stachel2@@msu.edu}
 #' @importFrom utils download.file unzip
 #' @importFrom raster raster
-#' @importFrom httr http_error 
-#' @importFrom httr config GET write_disk
+#' @importFrom httr http_error config GET write_disk progress
 #'@export
 getCDL <- function(x,year,alternativeUrl,location,https=TRUE, ssl.verifypeer = TRUE){
 
@@ -70,7 +69,7 @@ getCDL <- function(x,year,alternativeUrl,location,https=TRUE, ssl.verifypeer = T
           httr::write_disk(paste(
             location, sprintf("CDL_%d_%02d.zip", year, x[i]), sep = "/"), 
           overwrite = TRUE), 
-          config = httr::config(ssl_verifypeer = ssl.verifypeer), progress())
+          config = httr::config(ssl_verifypeer = ssl.verifypeer), httr::progress())
         
         utils::unzip(paste(
           location, sprintf("CDL_%d_%02d.zip", year, x[i]), sep="/"), 


### PR DESCRIPTION
I was getting an error:

> Error in progress() : could not find function "progress"

If the `httr` package was not manually loaded alongside `cdlTools`